### PR TITLE
Solve task 3: RISC-Z

### DIFF
--- a/.github/workflows/task-3-risc-z.yml
+++ b/.github/workflows/task-3-risc-z.yml
@@ -1,0 +1,56 @@
+name: "Task 3: RISC-Z"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install RISC-V binutils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils-riscv64-unknown-elf
+
+      - name: Setup build configs
+        working-directory: 03.RISC-Z
+        run: ./_setup_build_configs.sh
+
+      - name: Build RISC-Z
+        working-directory: 03.RISC-Z/build/release
+        run: cmake --build .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: risc-z-build-release
+          path: 03.RISC-Z/build/release
+
+  download-and-test:
+    runs-on: ubuntu-latest
+    needs: build-and-upload
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: risc-z-build-release
+          path: 03.RISC-Z/build/release
+
+      - name: Set executable permissions
+        working-directory: 03.RISC-Z/build/release
+        run: chmod +x risc-z test_main test_cpu
+
+      - name: Run tests
+        working-directory: 03.RISC-Z/build/release
+        run: ctest -V

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "03.RISC-Z/utest"]
+	path = 03.RISC-Z/utest
+	url = https://github.com/sheredom/utest.h.git

--- a/03.RISC-Z/CMakeLists.txt
+++ b/03.RISC-Z/CMakeLists.txt
@@ -20,3 +20,27 @@ set(SRC_LIST main.c cpu.c memory.c)
 
 add_executable(risc-z ${SRC_LIST})
 
+add_custom_command(
+    OUTPUT fib.bin fib.elf fib.o
+    COMMAND riscv64-unknown-elf-as ${CMAKE_SOURCE_DIR}/fib.s -o fib.o
+    COMMAND riscv64-unknown-elf-ld fib.o -o fib.elf
+    COMMAND riscv64-unknown-elf-objcopy -O binary fib.elf fib.bin
+    DEPENDS ${CMAKE_SOURCE_DIR}/fib.s
+    VERBATIM
+)
+
+add_custom_target(fib DEPENDS fib.bin)
+
+enable_testing()
+
+set(TEST_SRC_LIST test_cpu.c cpu.c memory.c)
+add_executable(test_cpu ${TEST_SRC_LIST})
+add_test(NAME CpuTests COMMAND test_cpu)
+
+set(TEST_MAIN_SRC_LIST test_main.c)
+add_executable(test_main ${TEST_MAIN_SRC_LIST})
+add_dependencies(test_main risc-z fib)
+add_test(NAME IntegrationTests COMMAND test_main)
+set_tests_properties(IntegrationTests PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/03.RISC-Z/CMakeLists.txt
+++ b/03.RISC-Z/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.25)
+project(RISC-Z)
+
+# set(CMAKE_GENERATOR "Unix Makefiles")
+# set(CMAKE_GENERATOR "Ninja")
+
+set(CMAKE_DEBUG_POSTFIX d)
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("debug mode")
+    add_compile_definitions(DEBUG)
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    message("release mode")
+    add_compile_definitions(NDEBUG)
+endif(CMAKE_BUILD_TYPE MATCHES Release)
+
+set(SRC_LIST main.c cpu.c memory.c)
+
+add_executable(risc-z ${SRC_LIST})
+

--- a/03.RISC-Z/README.md
+++ b/03.RISC-Z/README.md
@@ -1,0 +1,30 @@
+# Ссылки
+
+## Справочные данные
+
+### Набор инструкций RISC-V
+
+https://mark.theis.site/riscv/
+
+### Кодирование инструкций RISC-V
+
+[Спецификация 2019](https://web.archive.org/web/20241123032239/https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf) стр. 129–131.
+[Спецификация 2024](https://drive.google.com/file/d/1uviu1nH-tScFfgrovvFCrj7Omv8tFtkp/view) стр. 553–555.
+
+## Инструменты
+
+### GodBolt
+
+https://godbolt.org/z/Ye14v1v7W
+
+### Симулятор Venus
+
+Доделанный и актуальный:
+
+* [Симулятор](https://github.com/61c-teach/venus)
+* [ECalls](https://github.com/61c-teach/venus/wiki/Environmental-Calls)
+
+Оригинальный:
+
+* [Симулятор](https://venus.kvakil.me/)
+* [ECalls](https://github.com/kvakil/venus/wiki/Environmental-Calls)

--- a/03.RISC-Z/_setup_build_configs.sh
+++ b/03.RISC-Z/_setup_build_configs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf ./build
+
+cmake -S . -B build/debug -DCMAKE_BUILD_TYPE=DEBUG
+cmake -S . -B build/release -DCMAKE_BUILD_TYPE=RELEASE

--- a/03.RISC-Z/cpu.c
+++ b/03.RISC-Z/cpu.c
@@ -1,0 +1,236 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "cpu.h"
+#include "memory.h"
+
+#define FUNC3_OFFS 12
+#define FUNC7_OFFS 24
+#define OPCODE_MASK 0b1111111u
+#define FUNC3_MASK  (0b111u << FUNC3_OFFS)
+#define FUNC7_MASK  (0b1111111u << FUNC7_OFFS)
+
+/**
+ * @brief Opcodes to determine instruction format
+ * 
+ */
+enum rz_formats { // C23
+    LUI_FORMAT    = 0b0110111u,
+    AUIPC_FORMAT  = 0b0010111u,
+    J_FORMAT  = 0b1101111u,
+    JALR_FORMAT = 0b1100111u, // JALR
+    R_FORMAT  = 0b0110011u,
+    S_FORMAT  = 0b0100011u,
+    L_FORMAT =  0b0000011u, // Load, I-format
+    I_FORMAT = 0b0010011u, // ADDI..ANDI, SLLI, SRLI, SRAI
+    MEM_FORMAT = 0b0001111u, // e.g. FENCE
+    SYS_FORMAT = 0b1110011u, // e.g. ECALL, EBREAK
+};
+
+/**
+ * @brief R-format CODE | F3 | F7
+ * 
+ */
+ enum rz_r_codes {
+    ADD_CODE = R_FORMAT | ( 0b000u << FUNC3_OFFS ) | ( 0b0000000u << FUNC7_OFFS ),
+    SUB_CODE = R_FORMAT | ( 0b000u << FUNC3_OFFS ) | ( 0b0100000u << FUNC7_OFFS ),
+    XOR_CODE = R_FORMAT | ( 0b100u << FUNC3_OFFS ) | ( 0b0000000u << FUNC7_OFFS ),
+ };
+
+ /**
+  * @brief I-format code | F3 [ | F7 ]
+  * 
+  */
+enum rz_i_codes {
+    ADDI_CODE = I_FORMAT | ( 0b000u << FUNC3_OFFS ),
+    SLLI_CODE = I_FORMAT | ( 0b001u << FUNC3_OFFS ),
+};
+
+/**
+ * @brief U-format code
+ * 
+ */
+enum rz_u_codes {
+    LUI_CODE = LUI_FORMAT,
+    AUIPC_CODE = AUIPC_FORMAT,
+};
+
+enum rz_sys_codes {
+    ECALL_CODE = SYS_FORMAT,
+    EBREAK_CODE = SYS_FORMAT | ( 1u << 20 ),
+};
+
+/**
+ * @brief Represent RISC-V machine code for LE host-machines
+ * 
+ */
+typedef union {
+    rz_register_t whole;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned f7: 7;
+    } r;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned imm0_11: 12;
+    } i;
+    struct {
+        unsigned op: 7;
+        unsigned imm0_4: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned imm5_11: 7;
+    } s;
+    struct {
+        unsigned op: 7;
+        unsigned imm11: 1;
+        unsigned imm1_4: 4;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned imm5_10: 6;
+        unsigned imm12: 1;
+    } b;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned imm12_31: 20;
+    } u;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned imm12_19: 8;
+        unsigned imm11: 1;
+        unsigned imm1_10: 10;
+        unsigned imm20: 1;
+    } j;
+} rz_instruction_t;
+
+struct rz_cpu_s {
+    const char *info;
+    rz_register_t r_pc, r_x[32];
+};
+
+const char *rz_cpu_info(const rz_cpu_p pcpu)
+{
+    return pcpu->info;
+}
+
+rz_cpu_p rz_create_cpu(void){
+    rz_cpu_p pcpu = malloc(sizeof(rz_cpu_t));
+    pcpu->info = "RISC-Z.32.2023";
+
+    pcpu->r_pc = TEXT_OFFSET;
+
+    memset(pcpu->r_x, 0, sizeof(pcpu->r_x));
+    pcpu->r_x[2] = STACK_OFFSET + STACK_SIZE - (unsigned) sizeof(rz_register_t); // sp
+    pcpu->r_x[3] = DATA_OFFSET; // gp
+
+    return pcpu;
+}
+
+void rz_free_cpu(rz_cpu_p pcpu){
+    free(pcpu);
+}
+
+bool rz_r_cycle(rz_cpu_p pcpu, rz_instruction_t instr) {
+    switch(instr.whole & (OPCODE_MASK | FUNC3_MASK | FUNC7_MASK)) {
+        case ADD_CODE:
+            pcpu->r_x[instr.r.rd] = pcpu->r_x[instr.r.rs1] + pcpu->r_x[instr.r.rs2];
+        break;
+        case SUB_CODE:
+            pcpu->r_x[instr.r.rd] = pcpu->r_x[instr.r.rs1] - pcpu->r_x[instr.r.rs2];
+        break;
+        case XOR_CODE:
+            pcpu->r_x[instr.r.rd] = pcpu->r_x[instr.r.rs1] ^ pcpu->r_x[instr.r.rs2];
+        break;
+        default:
+            return false;
+    }
+    return true;
+}
+
+static inline rz_register_t sign_extend(unsigned some_bits, int how_many_bits) {
+    rz_register_t result = some_bits;
+    if(1 << (how_many_bits - 1) & result) // then negative
+        result |= -1 << how_many_bits; // -1 is full of 1s
+    return result;
+}
+
+bool rz_i_cycle(rz_cpu_p pcpu, rz_instruction_t instr) {
+    switch(instr.whole & (OPCODE_MASK | FUNC3_MASK)) {
+        case ADDI_CODE:
+            pcpu->r_x[instr.i.rd] = pcpu->r_x[instr.i.rs1] + sign_extend(instr.i.imm0_11, 12);
+        break;
+        case SLLI_CODE:
+            pcpu->r_x[instr.i.rd] = pcpu->r_x[instr.i.rs1] << instr.r.rs2;
+        break;
+        break;
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool rz_sys_cycle(rz_cpu_p pcpu, rz_instruction_t instr) {
+    switch(instr.whole & (1u << 20)){
+        case 0:
+            return true; // return rz_ecall();
+        case 1:
+        default:
+            return false;
+    }
+}
+
+bool rz_cycle(rz_cpu_p pcpu) {
+    pcpu->r_x[0] = 0u;
+    rz_instruction_t instr = *((rz_instruction_t *)mem_access(pcpu->r_pc));
+    bool goon = true;
+
+    switch(instr.whole & OPCODE_MASK) {
+        case R_FORMAT:
+            goon = rz_r_cycle(pcpu, instr);
+        break;
+        case I_FORMAT:
+            goon = rz_i_cycle(pcpu, instr);
+        break;
+        case L_FORMAT:
+        break;
+        case S_FORMAT:
+        break;
+        case LUI_FORMAT:
+            pcpu->r_x[instr.u.rd] = instr.u.imm12_31 << 12;
+        break;
+        case AUIPC_FORMAT:
+            pcpu->r_x[instr.u.rd] = (instr.u.imm12_31 << 12) + pcpu->r_pc;
+        break;
+
+        case J_FORMAT:
+        break;
+        case JALR_FORMAT:
+        break;
+
+        case MEM_FORMAT:
+        break;
+        case SYS_FORMAT:
+            goon = rz_sys_cycle(pcpu, instr);
+        break;
+        default:
+            fprintf(stderr, "Invalid instruction %08X format, opcode %08X\n", instr.whole, instr.whole & OPCODE_MASK);
+            goon = false;
+    }
+    pcpu->r_pc += sizeof(rz_instruction_t);
+    return goon;
+}

--- a/03.RISC-Z/cpu.h
+++ b/03.RISC-Z/cpu.h
@@ -1,0 +1,45 @@
+#ifndef __CPU_H__
+#define __CPU_H__
+
+#include <stdbool.h>
+
+struct rz_cpu_s;
+
+/**
+ * @brief Types to represent instance of RISC-Z CPU and pointer to it
+ * 
+ */
+typedef struct rz_cpu_s rz_cpu_t, *rz_cpu_p;
+
+/**
+ * @brief Create a RISC-Z CPU
+ * 
+ * @return rz_cpu_p pointer to CPU instance
+ */
+rz_cpu_p rz_create_cpu(void);
+
+/**
+ * @brief Deinitialize RISC-Z CPU instance
+ * 
+ * @param pcpu pointer to CPU instance
+ */
+void rz_free_cpu(rz_cpu_p pcpu);
+
+/**
+ * @brief Get CPU info string
+ * 
+ * @param pcpu pointer to CPU instance
+ * @return const char* CPU info string
+ */
+const char *rz_cpu_info(const rz_cpu_p pcpu);
+
+/**
+ * @brief Execute one CPU instruction
+ * 
+ * @param pcpu pointer to CPU instance
+ * @return true when it is ready to execute more
+ * @return false when it wants to finish
+ */
+bool rz_cycle(rz_cpu_p pcpu);
+
+#endif // CPU_H__

--- a/03.RISC-Z/cpu_internal.h
+++ b/03.RISC-Z/cpu_internal.h
@@ -1,0 +1,136 @@
+#ifndef __CPU_INTERNAL_H__
+#define __CPU_INTERNAL_H__
+
+#include "memory.h"
+
+#define FUNC3_OFFS 12
+#define FUNC7_OFFS 24
+#define OPCODE_MASK 0b1111111u
+#define FUNC3_MASK  (0b111u << FUNC3_OFFS)
+#define FUNC7_MASK  (0b1111111u << FUNC7_OFFS)
+
+/**
+ * @brief Opcodes to determine instruction format
+ * 
+ */
+enum rz_formats { // C23
+    LUI_FORMAT    = 0b0110111u,
+    AUIPC_FORMAT  = 0b0010111u,
+    J_FORMAT  = 0b1101111u,
+    JALR_FORMAT = 0b1100111u, // JALR
+    R_FORMAT  = 0b0110011u,
+    S_FORMAT  = 0b0100011u,
+    L_FORMAT =  0b0000011u, // Load, I-format
+    I_FORMAT = 0b0010011u, // ADDI..ANDI, SLLI, SRLI, SRAI
+    MEM_FORMAT = 0b0001111u, // e.g. FENCE
+    SYS_FORMAT = 0b1110011u, // e.g. ECALL, EBREAK
+    B_FORMAT  = 0b1100011u,
+};
+
+/**
+ * @brief R-format CODE | F3 | F7
+ * 
+ */
+enum rz_r_codes {
+    ADD_CODE = R_FORMAT | ( 0b000u << FUNC3_OFFS ) | ( 0b0000000u << FUNC7_OFFS ),
+    SUB_CODE = R_FORMAT | ( 0b000u << FUNC3_OFFS ) | ( 0b0100000u << FUNC7_OFFS ),
+    XOR_CODE = R_FORMAT | ( 0b100u << FUNC3_OFFS ) | ( 0b0000000u << FUNC7_OFFS ),
+};
+
+/**
+  * @brief I-format code | F3 [ | F7 ]
+  * 
+ */
+enum rz_i_codes {
+    ADDI_CODE = I_FORMAT | ( 0b000u << FUNC3_OFFS ),
+    SLLI_CODE = I_FORMAT | ( 0b001u << FUNC3_OFFS ),
+};
+
+/**
+ * @brief U-format code
+ * 
+ */
+enum rz_u_codes {
+    LUI_CODE = LUI_FORMAT,
+    AUIPC_CODE = AUIPC_FORMAT,
+};
+
+enum rz_sys_codes {
+    ECALL_CODE = SYS_FORMAT,
+    EBREAK_CODE = SYS_FORMAT | ( 1u << 20 ),
+};
+
+enum rz_ecall_codes {
+    PRINT_INT = 1,
+    READ_INT = 2,
+};
+
+enum rz_branch_codes {
+    BEQ = 0b000,
+    BNE = 0b001,
+    BLT = 0b100,
+    BGE = 0b101,
+    BLTU = 0b110,
+    BGEU = 0b111,
+};
+
+/**
+ * @brief Represent RISC-V machine code for LE host-machines
+ * 
+ */
+typedef union {
+    rz_register_t whole;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned f7: 7;
+    } r;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned imm0_11: 12;
+    } i;
+    struct {
+        unsigned op: 7;
+        unsigned imm0_4: 5;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned imm5_11: 7;
+    } s;
+    struct {
+        unsigned op: 7;
+        unsigned imm11: 1;
+        unsigned imm1_4: 4;
+        unsigned f3: 3;
+        unsigned rs1: 5;
+        unsigned rs2: 5;
+        unsigned imm5_10: 6;
+        unsigned imm12: 1;
+    } b;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned imm12_31: 20;
+    } u;
+    struct {
+        unsigned op: 7;
+        unsigned rd: 5;
+        unsigned imm12_19: 8;
+        unsigned imm11: 1;
+        unsigned imm1_10: 10;
+        unsigned imm20: 1;
+    } j;
+} rz_instruction_t;
+
+struct rz_cpu_s {
+    const char *info;
+    rz_register_t r_pc, r_x[32];
+};
+
+#endif // __CPU_INTERNAL_H__

--- a/03.RISC-Z/fib.s
+++ b/03.RISC-Z/fib.s
@@ -1,0 +1,28 @@
+        .text
+        .globl _start
+
+_start:
+        li a0, 2
+        ecall
+        mv a0, a1
+        jal ra, fib
+        mv a1, a0
+        li a0, 1
+        ecall
+        ebreak
+
+fib:
+        li a1, 0
+        li a2, 1
+
+fib_loop:
+        beq a0, zero, fib_end
+        add a3, a1, a2
+        mv a1, a2
+        mv a2, a3
+        addi a0, a0, -1
+        jal zero, fib_loop
+
+fib_end:
+        mv a0, a1
+        jalr zero, ra

--- a/03.RISC-Z/hex2bin.py
+++ b/03.RISC-Z/hex2bin.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import sys
+
+with open(sys.argv[1], 'wb') as o:
+    for l in sys.stdin.readlines():
+        o.write(int(l, 16).to_bytes(4, 'little'))

--- a/03.RISC-Z/hex2bin.py
+++ b/03.RISC-Z/hex2bin.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-import sys
-
-with open(sys.argv[1], 'wb') as o:
-    for l in sys.stdin.readlines():
-        o.write(int(l, 16).to_bytes(4, 'little'))

--- a/03.RISC-Z/main.c
+++ b/03.RISC-Z/main.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include "cpu.h"
+#include "memory.h"
+
+int main(int argc, const char *argv[])
+{
+    #ifdef DEBUG
+    puts("DEBUG");
+    #endif
+
+    #ifdef NDEBUG
+    puts("RELEASE");
+    #endif
+
+    rz_cpu_p pcpu = rz_create_cpu();
+    printf("CPU Info: %s\n", rz_cpu_info(pcpu));
+
+    // load dumps
+    FILE *code_file = fopen(argv[1], "rb");
+
+    fread(mem_access(TEXT_OFFSET), 1, TEXT_SIZE, code_file);
+    fclose(code_file);
+
+    while(rz_cycle(pcpu));
+
+    rz_free_cpu(pcpu);
+
+    return 0;
+}

--- a/03.RISC-Z/memory.c
+++ b/03.RISC-Z/memory.c
@@ -1,0 +1,28 @@
+#include <stddef.h>
+#include "memory.h"
+
+typedef struct {
+    rz_address_t base;
+    size_t size;
+    uint8_t *data;
+} memory_region_t;
+
+static uint8_t text_memory[TEXT_SIZE];
+static uint8_t data_memory[DATA_SIZE];
+static uint8_t stack_memory[STACK_SIZE];
+
+memory_region_t regions[] = {
+    { TEXT_OFFSET,  TEXT_SIZE, text_memory },
+    { DATA_OFFSET,  DATA_SIZE, data_memory },
+    { STACK_OFFSET, STACK_SIZE, stack_memory },
+};
+
+void *mem_access(rz_address_t addr) {
+    static uint8_t nowhere;
+    for(int i = 0; i < 3; ++i) {
+        if(regions[i].base <= addr && addr < regions[i].base + regions[i].size)
+            return regions[i].data + addr - regions[i].base;
+    }
+    nowhere = 0;
+    return &nowhere;
+}

--- a/03.RISC-Z/memory.h
+++ b/03.RISC-Z/memory.h
@@ -1,0 +1,22 @@
+#ifndef __MEMORY_H__
+#define __MEMORY_H__
+
+#include "misc.h"
+
+#define TEXT_SIZE (1UL << 14)
+#define TEXT_OFFSET 0UL
+
+#define DATA_SIZE (1UL << 14)
+#define DATA_OFFSET 0x10000000UL
+
+#define STACK_SIZE (1UL << 14)
+#define STACK_OFFSET 0x7FFFFF00UL
+
+/**
+ * @brief ...
+ *
+ * @param ...
+ */
+void *mem_access(rz_address_t addr);
+
+#endif // MEMORY_H__

--- a/03.RISC-Z/misc.h
+++ b/03.RISC-Z/misc.h
@@ -1,0 +1,11 @@
+#ifndef __MISC_H__
+#define __MISC_H__
+
+#include <stdint.h>
+
+typedef uint32_t rz_register_t;
+
+typedef rz_register_t rz_address_t;
+// typedef rz_register_t rz_instruction_t;
+
+#endif // MISC_H__

--- a/03.RISC-Z/test_cpu.c
+++ b/03.RISC-Z/test_cpu.c
@@ -1,0 +1,264 @@
+#include <stdint.h>
+#include <stdio.h>
+#include "utest/utest.h"
+#include "cpu.h"
+#include "cpu_internal.h"
+#include "memory.h"
+
+struct RzCpuTestFixture {
+    rz_cpu_p cpu;
+};
+
+UTEST_F_SETUP(RzCpuTestFixture) {
+    utest_fixture->cpu = rz_create_cpu();
+    ASSERT_NE((void *)utest_fixture->cpu, NULL);
+    utest_fixture->cpu->r_pc = TEXT_OFFSET;
+}
+
+UTEST_F_TEARDOWN(RzCpuTestFixture) {
+    rz_free_cpu(utest_fixture->cpu);
+}
+
+UTEST_F(RzCpuTestFixture, EcallPrint) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = ECALL_CODE;
+    utest_fixture->cpu->r_x[10] = PRINT_INT;
+    utest_fixture->cpu->r_x[11] = 42;
+
+    FILE *original_stdout = stdout;
+    FILE *temp_file = tmpfile();
+    stdout = temp_file;
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    fflush(temp_file);
+    stdout = original_stdout;
+
+    rewind(temp_file);
+    char output[16] = {0};
+    fgets(output, sizeof(output), temp_file), NULL;
+    fclose(temp_file);
+
+    ASSERT_STREQ("42\n", output);
+}
+
+UTEST_F(RzCpuTestFixture, EcallRead) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = ECALL_CODE;
+    utest_fixture->cpu->r_x[10] = READ_INT;
+
+    FILE *original_stdin = stdin;
+    FILE *temp_input = tmpfile();
+    fprintf(temp_input, "123\n");
+    rewind(temp_input);
+    stdin = temp_input;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    stdin = original_stdin;
+    fclose(temp_input);
+
+    ASSERT_EQ(123, utest_fixture->cpu->r_x[11]);
+}
+
+UTEST_F(RzCpuTestFixture, EcallUnsupported) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = ECALL_CODE;
+    utest_fixture->cpu->r_x[10] = -1;
+
+    ASSERT_FALSE(rz_cycle(utest_fixture->cpu));
+}
+
+UTEST_F(RzCpuTestFixture, BranchEqualPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BEQ << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 5;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchEqualNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BEQ << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchNotEqualPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BNE << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchNotEqualNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BNE << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 5;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchLessThanPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BLT << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 4;
+    utest_fixture->cpu->r_x[2] = 5;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchLessThanNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BLT << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchGreaterEqualPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BGE << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchGreaterEqualNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BGE << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 4;
+    utest_fixture->cpu->r_x[2] = 5;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchLessThanUnsignedPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BLTU << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 3;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchLessThanUnsignedNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BLTU << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchGreaterEqualUnsignedPos) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BGEU << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 5;
+    utest_fixture->cpu->r_x[2] = 4;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 8 * 2, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, BranchGreaterEqualUnsignedNeg) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = B_FORMAT | (BGEU << FUNC3_OFFS);
+    instr->b.rs1 = 1;
+    instr->b.rs2 = 2;
+    instr->b.imm1_4 = 8;
+
+    utest_fixture->cpu->r_x[1] = 4;
+    utest_fixture->cpu->r_x[2] = 5;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, JumpAndLink) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+
+    instr->whole = 0b00000100000000000001 << 12;
+    instr->j.op = J_FORMAT;
+    instr->j.rd = 1;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_x[1]);
+    ASSERT_EQ(TEXT_OFFSET + 0b00000001000001000000, utest_fixture->cpu->r_pc);
+}
+
+UTEST_F(RzCpuTestFixture, JumpAndLinkRegister) {
+    rz_instruction_t *instr = (rz_instruction_t *)mem_access(utest_fixture->cpu->r_pc);
+    instr->whole = JALR_FORMAT;
+    instr->i.rd = 1;
+    instr->i.rs1 = 2;
+    instr->i.imm0_11 = 4;
+
+    utest_fixture->cpu->r_x[2] = 100;
+
+    ASSERT_TRUE(rz_cycle(utest_fixture->cpu));
+    ASSERT_EQ(TEXT_OFFSET + 4, utest_fixture->cpu->r_x[1]);
+    ASSERT_EQ(104, utest_fixture->cpu->r_pc);
+}
+
+UTEST_MAIN()

--- a/03.RISC-Z/test_main.c
+++ b/03.RISC-Z/test_main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "utest/utest.h"
+
+UTEST(main, Fib_10) {
+    FILE *fp = popen("echo 10 | ./risc-z fib.bin | tail -n 1", "r");
+    fflush(fp);
+    char output[64];
+    fgets(output, 64, fp);
+    pclose(fp);
+    ASSERT_STREQ("55\n", output);
+}
+
+UTEST_MAIN()

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ![Task 1 Status](https://github.com/IlyaMuravjov/mm-tools-course/actions/workflows/task-1-IO-flush.yml/badge.svg)
 ![Task 2 Status](https://github.com/IlyaMuravjov/mm-tools-course/actions/workflows/task-2-overcommit.yml/badge.svg)
+![Task 3 Status](https://github.com/IlyaMuravjov/mm-tools-course/actions/workflows/task-3-risc-z.yml/badge.svg)
 
 This repository contains completed tasks from the ["Software Tools" course](https://hwproj.ru/courses/20022).
 
 ## Completed tasks
 1. [IO_flush](01.IO_flush/) &mdash; IO & flush experiments.
 2. [Overcommit](02.overcommit/) &mdash; memory overcommit experiments.
-3. [CI](.github/workflows/) &mdash; continuous integration.
+3. [RISC-Z](03.RISC-Z/) &mdash; RISC-V emulator.
+4. [CI](.github/workflows/) &mdash; continuous integration.


### PR DESCRIPTION
## Completed tasks

- [x] Add [base RISC-V emulator implementation](https://github.com/dluciv/Modern-Tools-Techs-BM.5666/tree/4ae6c795e61baad0ba47ddff3501ac24de739439/examples/C/03.B.RISC-Z)
- [x] Support `BEQ`, `BNE`, `BLT`, `BGE`, `BLTU`, `BGEU`, `JAL`, `JALR` instructions
- [x] Support `EBREAK` instruction (stops emulation)
- [x] Support `ECALL` instruction
   - To use an environmental call, load the ID into register `a0`, and load any arguments into `a1` - `a7`. Any return values will be stored in argument registers
   - The following environmental calls are currently supported
      | ID (`a0`)  | Name          | Description                                                         |
      | ---------- | ------------- | ------------------------------------------------------------------- |
      | 1          | print_int     | prints integer in `a1`                                              |
      | 2          | read_int      | reads integer into `a1`                                             |
- [x] Add unit tests for newly supported instructions
- [x] Add integration tests that emulate the `fib` program, which reads an integer, computes the Fibonacci number, and prints the result.
- [x] Configure CI